### PR TITLE
Pointer Events: do not always prevent click events

### DIFF
--- a/js/jquery.pointerEvents.js
+++ b/js/jquery.pointerEvents.js
@@ -103,6 +103,8 @@ if (!support.pointer)
 {
 	$.event.special.pointerdown =
 	{
+		preventClickEvents: false,
+
 		setup: function ()
 		{
 			var thisObject = this,
@@ -126,8 +128,10 @@ if (!support.pointer)
 				triggerCustomEvent(thisObject, "pointerdown", event);
 			});
 
-			// disable click since we listen to mousedown here
-			$this.on("click", preventDefault);
+			if ($.event.special.pointerdown.preventClickEvents)
+			{
+				$this.on("click", preventDefault);
+			}
 		}
 	};
 


### PR DESCRIPTION
Do not always prevent click events, as this can break normal desktop mouse functionality.
