### PR TITLE
$.msAjax JSON date parser fix

### DIFF
--- a/js/jquery.msAjax.js
+++ b/js/jquery.msAjax.js
@@ -24,6 +24,8 @@
         return value;
     };
     
+
+
     // Converts date strings in ISO8601 or Microsoft format to JavaScript dates
     var msJsonDateOnlySanitizer = function(key, value)
     {
@@ -32,26 +34,13 @@
             // Perform strict parsing so that strings that are not full dates are not parsed as dates
             // Example of a partial date:       "2013"
             // Example of a full ISO8601 date:  "2013-08-07T21:40:05.121+06:00"
-            
-            // Depends on ms date parsing in date-parse.js. True indicates to perform strict parsing.
-            var date = Date.parseISO(value, true); 
-            if (!isNaN(date))
+            if (!$.parseMsJSON.isNumericString(value))
             {
-                return new Date(date);
-            }
-
-            // Depends on ms date parsing in date-parse.js. This function is already strict.
-            date = Date.parseMsDate(value); 
-            if (!isNaN(date))
-            {
-                return new Date(date);
-            }
-
-            // Fall back on default date parsing
-            date = Date.parse(value); 
-            if (!isNaN(date))
-            {
-                return new Date(date);
+                var date = Date.parse(value);
+                if (!isNaN(date))
+                {
+                    return new Date(date);
+                }
             }
         }
 
@@ -76,6 +65,10 @@
         // ASMX puts all JSON in a "d" property.
 
         return typeof json.d != "undefined" ? json.d : json;
+    };
+
+    $.parseMsJSON.isNumericString = function(value) {
+        return new RegExp(/^-?[0-9]+\.?[0-9]*$/).test(value);
     };
 
     // Recurses through a JSON object and applies the specified reviver

--- a/test/jquery.msAjax.unittests.js
+++ b/test/jquery.msAjax.unittests.js
@@ -57,11 +57,33 @@ describe("jquery.msAjax()", function()
         .done(function(data, status)
         {
             // Mon, 06 Apr 2009 11:54:29 GMT
-            assert.equal(data.date.valueOf(), 1239018869048);
+            assert.strictEqual(data.date.valueOf(), 1239018869048);
             assert.equal(status, "success");
             done();
         });
-        
+
+    });
+
+    it("should not parse number strings as dates", function (done)
+    {
+        $.mockjax({
+            url: "/test.asmx",
+            contentType: "application/json",
+            responseText: JSON.stringify({d: {number: 2013, string: "002013"}})
+        });
+
+        $.msAjax(
+        {
+            url: "/test.asmx",
+            type: "GET"
+        })
+        .done(function (data, status)
+        {
+            assert.strictEqual(data.number, 2013);
+            assert.strictEqual(data.string, "002013");
+            assert.equal(status, "success");
+            done();
+        });
     });
 
     it("should parse a date string in UTC date format", function(done)
@@ -142,5 +164,20 @@ describe("jquery.msAjax()", function()
             done();
         });
         
+    });
+
+    it("validate $.parseMsJSON.isNumericString", function()
+    {
+        // true
+        assert.equal($.parseMsJSON.isNumericString("2013"), true, "should accept string with only numbers");
+        assert.equal($.parseMsJSON.isNumericString("-2013"), true, "should accept numbers prefixed with hyphen");
+        assert.equal($.parseMsJSON.isNumericString("2013.03"), true, "should accept numbers with periods");
+
+        // false
+        assert.equal($.parseMsJSON.isNumericString("2013.03.01"), false, "should reject strings with two periods");
+        assert.equal($.parseMsJSON.isNumericString("11-01"), false, "should reject strings with inclusive hyphens");
+        assert.equal($.parseMsJSON.isNumericString("2013-11-01"), false, "should reject dates");
+        assert.equal($.parseMsJSON.isNumericString("2009-04-06T11:54:29.048Z"), false, "should reject ISO dates");
+        assert.equal($.parseMsJSON.isNumericString("G930"), false, "should reject alphanumeric strings");
     });
 });


### PR DESCRIPTION
Added new string check to the msJsonParser used by msAjax to ensure strings are not just numbers. Added new test case for $.msAjax to show the original problem and to validate the string check method.
