### PR TITLE
Fix for main navigation with touch devices navigating.

### DIFF
--- a/js/jquery.menu.js
+++ b/js/jquery.menu.js
@@ -482,6 +482,13 @@
                 var toggleClick = function (e) {
                     var isBubbledClick = false;
 
+                    // If an item doesn't have a Panel object of its own, so it should act like a regular link.
+                    // This occurs only when the top-level item doesn't have a panel object, otherwise the panel.lenght will be 0
+                    if (!me.$panel) {
+                        location.href = $(e.target).closest('a').attr('href');
+                        return;
+                    }
+
                     if (me.$panel.length > 0) {
                         var $closestPanel = $(e.target).closest(".menu-panel");
                         if ($closestPanel.length > 0 && $closestPanel[0] === me.$panel[0]) {
@@ -491,12 +498,12 @@
 
                     // This event bubbled from a child panel's link (a leaf menu item).
                     // It doesn't have a Panel object of its own, so it should act like a regular link.
-                    if (isBubbledClick) {
+                    if (isBubbledClick || e.pointerType === 'mouse') {
                         // Don't let the document handler catch this event, or the menu would close.
                         e.stopPropagation();
 
-                        // Navitgate now
-                        location.href = $(e.target).closest("a").attr("href");
+                        // Navitgate because the click event is canceled
+                        location.href = $(e.target).closest('a').attr('href');
                         return;
                     }
 


### PR DESCRIPTION
Since we removed the polyfill's cancel of the click event we must cancel click within the jquery.menu.js file and navigate manually as a result of canceling the click event. Will be looking into better solution but this resolves the issues is a clean manor for now. I'm working on other changes to the jquery.menu.js now for tablet support and will be testing other solutions.
