### PR TITLE
Pointer Event polyfill, ontouchmove preventing scrolling fix

### DIFF
--- a/js/jquery.pointerEvents.js
+++ b/js/jquery.pointerEvents.js
@@ -211,7 +211,12 @@
             }
         }, function (pointerEventType, natives) {
             function onTouch(event) {
-                event.preventDefault(); // prevent the mouse event from firing as well
+                // prevent the mouse event from firing as well
+                // except for touchmove, preventing touchmove prevents scrolling,
+                // preventing this polyfill from working as expected when binded to large elements
+                if (event.type != "touchmove") {
+                    event.preventDefault();
+                }
                 triggerCustomEvent(this, pointerEventType, event);
             }
 


### PR DESCRIPTION
The ontouchmove event was being prevented, preventing scrolling while a jquery.menu.js was open. This in general isn't expected functionality.
