### PR TITLE
Cannot read property 'dialogCmd' of undefined

### DIFF
--- a/js/jquery.modalDialogContent.js
+++ b/js/jquery.modalDialogContent.js
@@ -396,6 +396,7 @@ $.modalDialog.create()
             qs = $.deparam(e.originalEvent ? e.originalEvent.data : e.data);
         } catch (ex) {
             //ignore- it wasn't a message for the dialog framework
+            return;
         }
 
         if (!qs.dialogCmd) {


### PR DESCRIPTION
Fixed an error in modalDialogContent.messageHandler when parsing the query string threw an exception and was supposed to be ignored.
