### PR TITLE
Add ModalDialog Plugin Support

### DIFF
--- a/js/jquery.modalDialog.js
+++ b/js/jquery.modalDialog.js
@@ -1113,6 +1113,59 @@
     // we will be hiding all content within the DOM and scrolling them to top.
     // When removing the host window content from the DOM, make the veil opaque to hide it.
     $.modalDialog.veilClass = "dialog-veil";
+    
+    // Initializer functions. The order determines the priority for creating dialog types.
+    var _typeInitializers = [
+    
+        // creates ajax or iframe dialog from url
+        function (settings) {
+            if (settings.url) {
+                if (settings.content) {
+                    throw new Error("Both url and content cannot be specified.");
+                } else if (settings.ajax) {
+                    return new AjaxDialog(settings);
+                } else {
+                    return new IFrameDialog(settings);
+                }
+            }
+            return null;
+        },
+    
+        // creates node dialog
+        function (settings) {
+            if (settings.content) {
+                var $content = $(settings.content);
+                if ($content.length === 0) {
+                    throw new Error("ModalDialog content not found");
+                }
+    
+                settings.content = $content;
+    
+                var dialog = new ModalDialog(settings);
+    
+                if (!settings.destroyOnClose) {
+                    $content.modalDialogInstance(dialog);
+                }
+    
+                return dialog;
+            }
+    
+            return null;
+        }
+    ];
+
+    // Allows for extending the ModalDialog prototype for other types of dialogs
+    // {function} f. A callback accepting the ModalDialog class to allow for extensibility. The function should return a type initializer function.
+    // {bool} addToBeginning. A flag determining whether the initializer function should go at the beginning or end of the the type initializers array.
+    $.modalDialog.registerPlugin = function (f, addToBeginning) {
+       var initializer = f.call(this, ModalDialog);
+       if(addToBeginning) {
+           _typeInitializers.unshift(initializer);
+       }
+       else {
+           _typeInitializers.push(initializer);
+       }
+    };
 
     // Creates a new dialog from the specified settings.
     $.modalDialog.create = function (settings) {
@@ -1133,29 +1186,15 @@
         }
 
         if (!dialog) {
-            if (settings.url) {
-                if (settings.content) {
-                    throw new Error("Both url and content cannot be specified.");
-                } else if (settings.ajax) {
-                    dialog = new AjaxDialog(settings);
-                } else {
-                    dialog = new IFrameDialog(settings);
+            // Loop over the initializers, creating a dialog object.
+            for (var i = 0; i < _typeInitializers.length; i++) {
+                dialog = _typeInitializers[i].call(this, settings);
+                if (dialog) {
+                    break;
                 }
-            } else if (settings.content) {
-
-                var $content = $(settings.content);
-                if ($content.length === 0) {
-                    throw new Error("ModalDialog content not found");
-                }
-
-                settings.content = $content;
-
-                dialog = new ModalDialog(settings);
-
-                if (!settings.destroyOnClose) {
-                    $content.modalDialogInstance(dialog);
-                }
-            } else {
+            }
+            
+            if (!dialog) {
                 throw new Error("No url or content node specified");
             }
 

--- a/test/jquery.modalDialog.plugin.unittests.js
+++ b/test/jquery.modalDialog.plugin.unittests.js
@@ -1,0 +1,50 @@
+/// <reference path="jquery.modalDialog.setup.html" />
+/// <reference path="jquery.modalDialog.setup.js" />
+
+describe("Plugins", function () {	
+	
+	it("should render the plugin modal", function (done) {
+		
+		var assert = chai.assert;
+		
+		// add a fake plugin
+		$.modalDialog.registerPlugin(function(ModalDialog) {			
+			// create the test dialog
+			var TestDialog = function () {
+				ModalDialog.apply(this, arguments);
+			};
+			
+			$.extend(TestDialog.prototype, ModalDialog.prototype);
+	
+			TestDialog.prototype.dialogType = "test";
+			
+			TestDialog.prototype._buildContent = function () {
+				this.$content =  $("<div class='dialog-content'>This is a test</div>");
+			};
+			
+			// add an initializer function
+			var initializer = function(settings) {
+				if(settings.isTest === true) {
+					return new TestDialog(settings);
+				}
+				return null;
+			};
+			
+			return initializer;
+		
+		}, true);		
+		
+		// create the dialog of the plugin type
+        var dialog = $.modalDialog.create({isTest: true});
+
+        dialog
+            .open()
+            .then(
+                function () {
+                    assert.equal($.trim(dialog.$container.find(".dialog-content").text()), "This is a test");
+                    return dialog.close();
+                })
+            .then(done);
+    });
+	
+});


### PR DESCRIPTION
Added support for modal dialog plugins to create custom dialog types.

$.modalDialog.registerPlugin accepts a callback that expects modalDialog
and initializers parameters. The ModalDialog parameter allows for
extending the prototype to create custom dialog types and the
intializers array can be prepended with a new function to create a
dialog of the custom type.

The former if/else construction logic is moved into the
_typeInitializers function array. If a function returns null, the next
one is called to try and create a dialog of that type.

Added unit tests for the plugin.