### PR TITLE
RichTooltips - visual improvements to arrows

### DIFF
--- a/css/jquery.richTooltip.less
+++ b/css/jquery.richTooltip.less
@@ -1,5 +1,4 @@
 @import url(lib/mixin_lib.less);
-@import url(css-arrows.less);
 
 [data-rel="tooltip"] + aside,
 .rich-tooltip-content
@@ -20,7 +19,7 @@
 	padding: 6px;
 
 	// box shadow
-	.drop-shadow(0, 2px, 2px, 2px, 0.4);
+	.drop-shadow(0, 2px, 4px, 0, 0.4);
 
 	// javascript applies:
 	// top
@@ -36,10 +35,72 @@
 
 	.rich-tooltip-arrow
 	{
-		@size: 15px;
-		@border-width: 1px;
+        // container that holds the arrowhead, and clips it via overflow:hidden
+        position: absolute;
+        overflow: hidden;
+        width: 39px;
+        height: 14px;
+        
+        &.north
+        {
+            top: -13px;
+            left: 50%;
+            .transform(translateX(-50%)); 
+        }
+        &.south
+        {
+            left: 50%;
+            bottom: -13px;
+            .transform(translateX(-50%) rotate(180deg)); 
+        }
+        &.west
+        {
+            top: 50%;
+            left: -26px;
+            .transform(translateY(-50%) rotate(-90deg));
+            border-bottom: 1px solid @white;
+        }
+        &.east
+        {
+            top: 50%;
+            right: -26px;
+            .transform(translateY(-50%) rotate(90deg));
+            border-top: 1px solid @white;
+        }
 
-		.css-arrow(@size, @border-width, @silver, @white);
+        // the arrowhead itself. Naturally a diamond shape, it is turned into a triangle when clipped by its parent
+        &:before 
+        {
+            display: block;
+            content: " ";
+            position: absolute;
+            top: 3px;
+            left: 10px;
+            .transform(rotate(-45deg) skew(15deg, 15deg));  
+            width: 20px;
+            height: 20px;
+            background: @white;
+            pointer-events: none;
+        }
+        // getting the arrowhead's drop shadows to blend decently involved a lot of just eyeballing the numbers
+        &.north:before 
+        {
+            .drop-shadow(1px, -1px, 2px, 0, 0.4);
+        }
+        &.south:before 
+        {
+            .drop-shadow(3px, -4px, 3px, 0, 0.3);
+        }
+        &.west:before 
+        {
+            top: 4px;
+            .drop-shadow(-2px, 2px, 3px, 4px, 0.3);
+        }
+        &.east:before 
+        {
+            top: 4px;
+            .drop-shadow(0, 2px, 4px, 4px, 0.3);
+        }
 	}
 
 	@media screen and (max-device-width: 480px)
@@ -74,12 +135,3 @@
 		}
 	}
 }
-
-// allow access without javascript by hovering or by clicking and holding
-// body.nojs [data-rel="tooltip"]:hover + aside,
-// body.nojs [data-rel="tooltip"] + aside:hover,
-// body.nojs [data-rel="tooltip"]:active + aside,
-// body.nojs [data-rel="tooltip"] + aside:active
-// {
-// 	display: block;
-// }

--- a/css/lib/mixin_lib.less
+++ b/css/lib/mixin_lib.less
@@ -4,7 +4,7 @@
 
 //
 // rounded corners
-// (IE 6-8 will gracefully degrade to square corners)
+// (IE <=8 will gracefully degrade to square corners)
 //
 .rounded(@radius: 4px) 
 {
@@ -69,62 +69,52 @@
 .opacity(@opacity: 0.5) 
 {
   @filteropacity: @opacity * 100;
-  filter: ~"alpha(opacity=@{filteropacity})"; // for IE 6-8
-  -webkit-opacity: @opacity;
-  -moz-opacity:    @opacity;
+  filter: ~"alpha(opacity=@{filteropacity})"; // for IE<=-8
   opacity:         @opacity;
 }
 
 //
 // shadows
-// (IE 6-8 will gracefully degrade to no shadow)
+// (IE <=8 will gracefully degrade to no shadow)
 //
 .drop-shadow(@x-axis: 4px, @y-axis: 4px, @blur: 4px, @alpha: 0.4) 
 { 
   -webkit-box-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow:    @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
   box-shadow:         @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
 }
 .drop-shadow(@x-axis: 4px, @y-axis: 4px, @blur: 4px, @spread: 1px, @alpha: 0.4) // for shadows that need the spread property
 { 
   -webkit-box-shadow: @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
-  -moz-box-shadow:    @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
   box-shadow:         @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
 }
 .inner-shadow(@x-axis:0, @y-axis:1px, @blur:2px, @alpha: 0.4) 
 {
   -webkit-box-shadow: inset @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  -moz-box-shadow:    inset @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
   box-shadow:         inset @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
 }
 .inner-shadow(@x-axis:0, @y-axis:1px, @blur:2px, @spread: 1px, @alpha: 0.4) // for shadows that need the spread property
 {
   -webkit-box-shadow: inset @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
-  -moz-box-shadow:    inset @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
   box-shadow:         inset @x-axis @y-axis @blur @spread rgba(0, 0, 0, @alpha);
 }
 .box-shadow(@arguments)  // use .drop-shadow or .inner-shadow (above) instead unless you need this level of precision
 { 
   -webkit-box-shadow: @arguments;
-  -moz-box-shadow:    @arguments;
   box-shadow:         @arguments;
 }
 .box-shadow(@arguments1, @arguments2)  // for specifying two shadows on the same element
 { 
   -webkit-box-shadow: @arguments1, @arguments2;
-  -moz-box-shadow:    @arguments1, @arguments2;
   box-shadow:         @arguments1, @arguments2;
 }
 .box-shadow(@arguments1, @arguments2, @arguments3)  // for specifying three shadows on the same element
 { 
   -webkit-box-shadow: @arguments1, @arguments2, @arguments3;
-  -moz-box-shadow:    @arguments1, @arguments2, @arguments3;
   box-shadow:         @arguments1, @arguments2, @arguments3;
 }
 .drop-shadow-none()
 {
 	-webkit-box-shadow: none;
-	-moz-box-shadow:    none;
 	box-shadow:         none;
 }
 .box-shadow-none()
@@ -134,25 +124,21 @@
 .text-shadow-black(@x-axis: 0px, @y-axis: 1px, @blur: 1px, @alpha: 0.4) 
 { 
   -webkit-text-shadow: @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
-  -moz-text-shadow:    @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
   text-shadow:         @x-axis @y-axis @blur rgba(0, 0, 0, @alpha);
 }
 .text-shadow-white(@x-axis: 0px, @y-axis: 1px, @blur: 1px, @alpha: 0.4) 
 { 
   -webkit-text-shadow: @x-axis @y-axis @blur rgba(255, 255, 255, @alpha);
-  -moz-text-shadow:    @x-axis @y-axis @blur rgba(255, 255, 255, @alpha);
   text-shadow:         @x-axis @y-axis @blur rgba(255, 255, 255, @alpha);
 }
 .text-shadow(@x-axis: 0px, @y-axis: 1px, @blur: 1px, @color) // if the shadow is black or white, use .text-shadow-black or .text-shadow-white instead
 {
   -webkit-text-shadow: @x-axis @y-axis @blur @color;
-  -moz-text-shadow:    @x-axis @y-axis @blur @color;
   text-shadow:         @x-axis @y-axis @blur @color;
 }
 .text-shadow-none() 
 {
   -webkit-text-shadow: none;
-  -moz-text-shadow:    none;
   text-shadow:         none;
 }
 
@@ -172,7 +158,7 @@
 //
 // vertical linear gradients
 // (older IE will gracefully degrade to a flat color)
-// @color: fallback flat color (for IE 6 to 9)
+// @color: fallback flat color (for IE <=9)
 // @start: color at the top of the gradient
 // @stop:  color at the bottom of the gradient
 //
@@ -219,7 +205,6 @@
   background-image: e(%("url(%s)", @imageurl)), linear-gradient(to bottom,
                                   @start,
                                   @stop);							   
-  .ie6to8 &,
   .ie9 &
   {
 	background-color: @color; 
@@ -229,7 +214,7 @@
 
 //
 // backgrounds
-// note: this provides NO graceful degradation for IE6-8!
+// note: this provides NO graceful degradation for IE<=8!
 //
 .background-size(@value) 
 {
@@ -275,17 +260,14 @@
 	&:after
 	{
 		clear: both;
-	}
-	
-  // IE 6 and 7 don't support :before and :after, so they get this backfill
-	*zoom: 1;
+	}	
 }
 
 
 //
 // CSS3 transforms and animations
-// note: there is no support or backfill for IE6-8!
-// If you use these mixins, you will need to develop an alternate treatment for IE6-8.
+// note: there is no support or backfill for IE<=8!
+// If you use these mixins, you will need to develop an alternate treatment for IE<=8.
 //
 .transform(@arguments) 
 {

--- a/js/jquery.richTooltip.js
+++ b/js/jquery.richTooltip.js
@@ -85,7 +85,7 @@
 
         // no arrow found, create one
         if (this.arrow.length === 0) {
-            this.arrow = $('<div class="rich-tooltip-arrow"><div class="hack" /></div>').appendTo(this.content);
+            this.arrow = $('<div class="rich-tooltip-arrow"></div>').appendTo(this.content);
         }
 
         // anything with [data-rel="close"] can be used to close the tooltip
@@ -254,7 +254,7 @@
         }
     };
 
-    // padding constant used during position calculations
+    // padding constant used during position calculations. TODO: compute these dynamically based on the control's actual CSS
     var PADDING = 10;
     var ARROW_WIDTH = 15;
 
@@ -281,13 +281,6 @@
         });
 
         var pos = restrainedPos.pos;
-        var contextRect = this.context.clientRect();
-        var arrowPos = {
-            top: 'auto',
-            right: 'auto',
-            bottom: 'auto',
-            left: 'auto'
-        };
 
         if (restrainedPos.direction !== this.options.pos) {
             this.content
@@ -298,51 +291,13 @@
         // determine the new arrow direction
         var arrowDirection = this.options.arrowDirection || arrowDirections[restrainedPos.direction];
 
-        // position the arrow for top and bottom
-        switch (restrainedPos.direction) {
-        case 'north':
-        case 'south':
-            arrowPos.left = contextRect.left - pos.left + (contextRect.width / 2) - ARROW_WIDTH;
-            arrowPos[restrainedPos.direction === 'north' ? 'bottom' : 'top'] = 0;
-            break;
-
-        case 'east':
-        case 'west':
-            arrowPos.top = contextRect.top - pos.top + contextRect.height - ARROW_WIDTH;
-            arrowPos[restrainedPos.direction === 'east' ? 'left' : 'right'] = 0;
-            break;
-        }
-
-        // if we are changing the default behavior we have to adjust slightly
-        if (this.options.arrowStyle === 'inset') {
-            switch (arrowDirection) {
-            case 'north':
-                arrowPos.top += 1;
-                break;
-
-            case 'east':
-                arrowPos.left -= 1;
-                break;
-
-            case 'south':
-                arrowPos.top -= 1;
-                break;
-
-            case 'west':
-                arrowPos.left += 1;
-                break;
-            }
-        }
-
         this.content.css(pos);
 
         this.arrow
             // remove any previously added tooltip arrow direction class
             .removeClass(directions.join(' '))
             // add the tooltip arrow direction class
-            .addClass(arrowDirection)
-            // assign the new arrow styling
-            .css(arrowPos);
+            .addClass(arrowDirection);
     };
 
     $.fn.tooltip = $.fn.richTooltip = function jQueryTooltip(options) {


### PR DESCRIPTION
New look for richTooltip, with a shallower drop shadow, and with arrows that have real drop shadows.
Arrows are now drawn with CSS transforms rather than borders, and are positioned only via CSS (no more JS positioning)
Also removing some vendor prefixes in the LESS mixins that are no longer needed for the current set of supported browsers.