### PR TITLE
Add closeOnEscape attribute to jquery modal

### DIFF
--- a/js/jquery.modalDialog.getSettings.js
+++ b/js/jquery.modalDialog.getSettings.js
@@ -68,6 +68,7 @@
         "skin": parseNone,
         "enableHistory": parseBool,
         "closeOnBackgroundClick": parseBool,
+        "closeOnEscape": parseBool,
         "zIndex": parseInt
     };
 

--- a/js/jquery.modalDialog.js
+++ b/js/jquery.modalDialog.js
@@ -27,6 +27,7 @@
         preventEventBubbling: false, // If true, click and touch events are prevented from bubbling up to the document
         enableHistory: true, // If the history module is enabled, this can be used to disable history if set false
         closeOnBackgroundClick: true, // If true, a click on the background veil will close the dialog
+        closeOnEscape: true,// If true, hitting the escape key will close the dialog
         onopen: null,
         onclose: null,
         onbeforeopen: null,
@@ -251,7 +252,7 @@
 
     // If a user hits the ESC key, close the dialog or cancel it's opening.
     ModalDialog.prototype._keydownHandler = function (e) {
-        if (e.keyCode == 27) {
+        if (e.keyCode == 27 && this.settings.closeOnEscape) {
             if ($.modalDialog.getCurrent() === this) {
                 this.cancel();
             }

--- a/js/jquery.modalDialog.unobtrusive.js
+++ b/js/jquery.modalDialog.unobtrusive.js
@@ -14,6 +14,7 @@ Uses declarative syntax to define a dialog. Syntax:
     data-dialog-ajax="{true or false}"
     data-dialog-destroyonclose="{true or false}"
     data-dialog-closeonbackgroundclick="{true or false}"
+    data-dialog-closeonescape="{true or false}"
     data-dialog-zIndex="{default zIndex}"
     >link</a>
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-jsbeautifier": "~0.2.7",
     "grunt-lineending": "~0.2.2",
     "grunt-mkdir": "~0.1.2",
-    "grunt-js-test": "~1.4.8",
+    "grunt-js-test": "~1.5.12",
     "grunt-string-replace": "~0.2.7",
     "grunt-strip-code": "~0.1.2",
     "grunt-wget": "~0.1.2",

--- a/test/jquery.modalDialog.closeonescape.unittests.js
+++ b/test/jquery.modalDialog.closeonescape.unittests.js
@@ -1,0 +1,84 @@
+/// <reference path="jquery.modalDialog.setup.html" />
+/// <reference path="jquery.modalDialog.setup.js" />
+/// <reference path="../dependencies/jquery.timeout.js" />
+
+$.modalDialog.iframeLoadTimeout = 1000;
+$.modalDialog.animationDuration = 100;
+
+describe("jquery.modalDialog", function () {
+    this.timeout(6000);
+
+    var assert = chai.assert;
+
+    var delayedResolver = function (deferred) {
+        return function () {
+            setTimeout(function () {
+                deferred.resolve();
+            }, 0);
+        };
+    };
+
+    var wait = function () {
+        return $.timeout(100);
+    };
+    var esc = $.Event("keydown", { keyCode: 27 });
+    describe("#create()", function () {
+        it("should close the dialog when escape is pressed and closeOnEscape is true", function (done) {
+            
+            var dialog = $.modalDialog.create({
+                content: "#simpleDialog",
+                closeOnEscape: true
+            });
+
+
+            dialog
+                .open()
+                .then(function () {
+
+                    var deferred = $.Deferred();
+                    dialog.onclose.one(delayedResolver(deferred));
+                    
+                    dialog.$bg.trigger(esc);
+                    
+                    return deferred;
+
+                })
+                .then(function () {
+                    assert.ok(true);
+                    done();
+                });
+        });
+
+        it("should not close the dialog when escape is pressed and closeOnEscape is false", function (done) {
+            
+            var dialog = $.modalDialog.create({
+                content: "#simpleDialog",
+                closeOnEscape: false
+            });
+
+            var dialogClosed = false;
+            dialog.onclose.add(function () {
+                dialogClosed = true;
+            });
+
+
+            dialog
+                .open()
+                .then(wait)
+                .then(function () {
+                    dialog.$bg.trigger(esc);
+                })
+                .then(wait)
+                .then(function () {
+                    assert.isFalse(dialogClosed);
+                })
+                .then(function() {
+                    return dialog.close();
+                })
+                .then(function() {
+                    done();
+                });
+        });
+    });
+
+});


### PR DESCRIPTION
Adding a closeOnEscape attribute to ensure a user cannot exit the dialog by hitting the escape key.