### PR TITLE
Change modal dialog title from h1 (which is bad for SEO) to h2

### DIFF
--- a/css/jquery.modalDialog.css
+++ b/css/jquery.modalDialog.css
@@ -1,0 +1,90 @@
+.dialog-content {
+  display: none;
+}
+.dialog-content-container .dialog-content {
+  display: inherit;
+}
+.dialog-background {
+  position: absolute;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 10000;
+  display: none;
+}
+.dialog-background.dialog-veil {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+.dialog-background.dialog-veil-opaque {
+  background-color: #4F514F;
+}
+.dialog-background .dialog-loading-indicator {
+  position: absolute;
+  margin: auto;
+  top: 50%;
+  margin-top: -25px;
+  height: 50px;
+  width: 100%;
+  text-align: center;
+  z-index: 10001;
+}
+.dialog-background .dialog-loading-indicator span {
+  display: inline-block;
+}
+.dialog-container {
+  z-index: 10002;
+  position: absolute;
+  top: -700px;
+}
+.dialog-container.smallscreen {
+  width: 95%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.dialog-container .dialog-header {
+  *zoom: 1;
+  padding: 3px;
+  height: 40px;
+}
+.dialog-container .dialog-header:before,
+.dialog-container .dialog-header:after {
+  content: ".";
+  display: block;
+  height: 0;
+  overflow: hidden;
+}
+.dialog-container .dialog-header:after {
+  clear: both;
+}
+.dialog-container .dialog-header .dialog-header-text {
+  float: left;
+  margin-left: 10px;
+  margin-top: 13px;
+  margin-bottom: 0;
+}
+.dialog-container .dialog-header .dialog-close-button {
+  float: right;
+  display: block;
+}
+.dialog-container .dialog-header.draggable {
+  cursor: move;
+}
+.dialog-container .dialog-content-container {
+  position: relative;
+}
+.dialog-container .dialog-content-container iframe {
+  background-color: transparent;
+  z-index: 1;
+}
+.dialog-container .dialog-content-container .dialog-content-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+}

--- a/css/jquery.modalDialog.less
+++ b/css/jquery.modalDialog.less
@@ -7,10 +7,7 @@
 
 .dialog-content-container .dialog-content
 {
-	display: inherit;
-	
-	// IE7 does not properly recalculate display:inherit; when the parent changes
-	*display: block;
+	display: inherit;	
 }
 
 // Core dialog structure
@@ -67,20 +64,18 @@
 		.box-sizing(border-box);
 	}
 
-	// add spacing in case this is a large dialog
-	// padding-bottom: 10px; // padding breaks the drop shadows
-
 	.dialog-header
 	{
 		.clearfix();
 		padding: 3px;
 		height: 40px;
 
-		h1
+		.dialog-header-text
 		{
 			float: left;
 			margin-left: 10px;
 			margin-top: 13px;
+            margin-bottom: 0;
 		}
 
 		.dialog-close-button

--- a/css/jquery.modalDialog.skins.css
+++ b/css/jquery.modalDialog.skins.css
@@ -1,0 +1,168 @@
+.dialog-background .dialog-loading-indicator span {
+  background-image: url(../images/clock.gif);
+  width: 49px;
+  height: 50px;
+}
+.dialog-default-padding {
+  padding: 10px 10px 0 10px;
+}
+.dialog-skin-primary.dialog-container,
+.dialog-skin-neutral.dialog-container {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+}
+.dialog-skin-primary.dialog-container .dialog-header,
+.dialog-skin-neutral.dialog-container .dialog-header {
+  -webkit-border-top-right-radius: 10px;
+  -moz-border-radius-topright: 10px;
+  border-top-right-radius: 10px;
+  -webkit-border-bottom-right-radius: 0;
+  -moz-border-radius-bottomright: 0;
+  border-bottom-right-radius: 0;
+  -webkit-border-bottom-left-radius: 0;
+  -moz-border-radius-bottomleft: 0;
+  border-bottom-left-radius: 0;
+  -webkit-border-top-left-radius: 10px;
+  -moz-border-radius-topleft: 10px;
+  border-top-left-radius: 10px;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  background: #4D4D4F;
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #4D4D4F), color-stop(1, #313131));
+  background: -webkit-linear-gradient(top, #4D4D4F, #313131);
+  background: -moz-linear-gradient(center top, #4D4D4F 0%, #313131 100%);
+  background: -ms-linear-gradient(top, #4D4D4F, #313131);
+  background: linear-gradient(to bottom, #4D4D4F, #313131);
+}
+.dialog-skin-primary.dialog-container .dialog-header .dialog-header-text,
+.dialog-skin-neutral.dialog-container .dialog-header .dialog-header-text {
+  font-size: 16px;
+  color: white;
+}
+.dialog-skin-primary.dialog-container .dialog-header .dialog-close-button,
+.dialog-skin-neutral.dialog-container .dialog-header .dialog-close-button {
+  margin-top: 5px;
+  margin-right: 5px;
+  color: transparent;
+  text-decoration: none;
+  -webkit-border-radius: 12px;
+  -moz-border-radius: 12px;
+  border-radius: 12px;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  height: 24px;
+  width: 24px;
+  background-color: #fff;
+}
+.dialog-skin-primary.dialog-container .dialog-header .dialog-close-button-icon,
+.dialog-skin-neutral.dialog-container .dialog-header .dialog-close-button-icon {
+  display: inline-block;
+  background-image: url(../images/close.png);
+  background-repeat: no-repeat;
+  height: 18px;
+  width: 18px;
+  margin: 3px;
+}
+.dialog-skin-primary.dialog-container .dialog-content-container,
+.dialog-skin-neutral.dialog-container .dialog-content-container {
+  background-color: #fff;
+  -webkit-border-top-right-radius: 0;
+  -moz-border-radius-topright: 0;
+  border-top-right-radius: 0;
+  -webkit-border-bottom-right-radius: 10px;
+  -moz-border-radius-bottomright: 10px;
+  border-bottom-right-radius: 10px;
+  -webkit-border-bottom-left-radius: 10px;
+  -moz-border-radius-bottomleft: 10px;
+  border-bottom-left-radius: 10px;
+  -webkit-border-top-left-radius: 0;
+  -moz-border-radius-topleft: 0;
+  border-top-left-radius: 0;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  padding-bottom: 10px;
+}
+.dialog-skin-primary.dialog-container.dialog-visible,
+.dialog-skin-neutral.dialog-container.dialog-visible {
+  -webkit-box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.4);
+  box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.4);
+  -webkit-box-shadow: 4px 4px 4px 1px rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 4px 4px 4px 1px rgba(0, 0, 0, 0.4);
+  box-shadow: 4px 4px 4px 1px rgba(0, 0, 0, 0.4);
+}
+.dialog-skin-neutral.dialog-container .dialog-header {
+  background: #7f7f83;
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #7f7f83), color-stop(1, #4D4D4F));
+  background: -webkit-linear-gradient(top, #7f7f83, #4D4D4F);
+  background: -moz-linear-gradient(center top, #7f7f83 0%, #4D4D4F 100%);
+  background: -ms-linear-gradient(top, #7f7f83, #4D4D4F);
+  background: linear-gradient(to bottom, #7f7f83, #4D4D4F);
+}
+.dialog-skin-neutral.dialog-container .dialog-content-container {
+  background-color: #fff;
+}
+.dialog-skin-lightbox.dialog-background.dialog-veil {
+  background-color: rgba(0, 0, 0, 0.6);
+}
+.dialog-skin-lightbox.dialog-background.dialog-veil-opaque {
+  display: none;
+  background-color: #313131;
+}
+.dialog-skin-lightbox.dialog-container.smallscreen {
+  position: fixed;
+  margin: 0;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+.dialog-skin-lightbox.dialog-container .dialog-header {
+  background-color: #313131;
+}
+.dialog-skin-lightbox.dialog-container .dialog-header .dialog-header-text {
+  font-size: 16px;
+  color: white;
+}
+.dialog-skin-lightbox.dialog-container .dialog-header .dialog-close-button {
+  margin-top: 5px;
+  margin-right: 5px;
+  color: transparent;
+  text-decoration: none;
+  -webkit-border-radius: 12px;
+  -moz-border-radius: 12px;
+  border-radius: 12px;
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding-box;
+  background-clip: padding-box;
+  height: 24px;
+  width: 24px;
+  background-color: #fff;
+}
+.dialog-skin-lightbox.dialog-container .dialog-header .dialog-close-button-icon {
+  display: inline-block;
+  background-image: url(../images/close.png);
+  background-repeat: no-repeat;
+  height: 18px;
+  width: 18px;
+  margin: 3px;
+}
+.dialog-skin-lightbox.dialog-container .dialog-content-container {
+  background-color: #313131;
+  color: #fff;
+}
+.dialog-skin-lightbox.dialog-container .dialog-content-container a:hover {
+  color: inherit;
+}
+.dialog-skin-lightbox .dialog-content {
+  margin: 0;
+  padding: 0 13px;
+  min-height: 100px;
+}

--- a/css/jquery.modalDialog.skins.less
+++ b/css/jquery.modalDialog.skins.less
@@ -4,9 +4,8 @@
 // It is intended to be modified by developers to skin modal dialogs.
 
 @gradient-top:      #4D4D4F;
-@gradient-bottom:      #313131;
-@white:         #fff;
-
+@gradient-bottom:   #313131;
+@white:             #fff;
 
 @border-rounding-amount: 10px;
 
@@ -64,7 +63,7 @@
         .border-radius(@border-rounding-amount, 0, 0, @border-rounding-amount);
         .gradient(@gradient-top, @gradient-top, @gradient-bottom);
 
-        h1
+        .dialog-header-text
         {
             font-size: 16px;
             color: white;
@@ -139,7 +138,7 @@
         {
             background-color: @gradient-bottom;
 
-            h1
+            .dialog-header-text
             {
                 font-size: 16px;
                 color: white;
@@ -153,7 +152,8 @@
             background-color: @gradient-bottom;
             color: @white;
 
-            a:hover {
+            a:hover 
+            {
                 color: inherit;
             }
         }
@@ -166,17 +166,5 @@
         margin: 0;
         padding: 0 13px;
         min-height: 100px;
-    }
-}
-
-// OldIE fixes for skins
-.dialog-skin-primary, .dialog-skin-neutral
-{
-    // Only put the drop shadow on when its visible
-    &.dialog-visible.dialog-container
-    {
-        // The \9 is an IE hack that targets IE 6,7,8
-        background-color: #fff\9;
-        border: 1px #555 solid\9;
     }
 }

--- a/css/jquery.modalDialogContent.css
+++ b/css/jquery.modalDialogContent.css
@@ -1,0 +1,21 @@
+.ui-content {
+  overflow: inherit;
+}
+.ui-mobile .ui-page {
+  min-height: inherit;
+}
+body.ui-mobile-viewport {
+  margin: 10px;
+  height: inherit;
+}
+.ui-mobile [data-role=page] {
+  position: inherit;
+}
+.ui-mobile {
+  height: inherit;
+}
+div.ui-input-text input.ui-input-text,
+div.ui-input-text textarea.ui-input-text,
+.ui-input-search input.ui-input-text {
+  width: auto;
+}

--- a/css/jquery.richTooltip.css
+++ b/css/jquery.richTooltip.css
@@ -1,0 +1,200 @@
+[data-rel="tooltip"] + aside,
+.rich-tooltip-content {
+  display: none;
+  position: absolute;
+  box-sizing: border-box;
+  z-index: 10;
+  min-height: 30px;
+  background: #fff;
+  border: 1px solid #b5babf;
+  padding: 6px;
+  -webkit-box-shadow: 0 2px 2px 2px rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 0 2px 2px 2px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 2px 2px rgba(0, 0, 0, 0.4);
+}
+[data-rel="tooltip"] + aside .rich-tooltip-close,
+.rich-tooltip-content .rich-tooltip-close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow,
+.rich-tooltip-content .rich-tooltip-arrow {
+  position: absolute;
+  background: #fff;
+  width: 30px;
+  height: 0px;
+}
+.ie7 [data-rel="tooltip"] + aside .rich-tooltip-arrow,
+.ie7 .rich-tooltip-content .rich-tooltip-arrow {
+  display: none;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow .hack,
+.rich-tooltip-content .rich-tooltip-arrow .hack {
+  background: inherit;
+  width: 28px;
+  left: 1px;
+  height: 3px;
+  top: -2px;
+  position: absolute;
+  z-index: 1;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east .hack,
+.rich-tooltip-content .rich-tooltip-arrow.east .hack,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west .hack,
+.rich-tooltip-content .rich-tooltip-arrow.west .hack {
+  display: none;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow:after,
+.rich-tooltip-content .rich-tooltip-arrow:after,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow:before,
+.rich-tooltip-content .rich-tooltip-arrow:before {
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow:after,
+.rich-tooltip-content .rich-tooltip-arrow:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-width: 15px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow:before,
+.rich-tooltip-content .rich-tooltip-arrow:before {
+  border-color: rgba(190, 195, 197, 0);
+  border-width: 16px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:after,
+.rich-tooltip-content .rich-tooltip-arrow.north:after,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:before,
+.rich-tooltip-content .rich-tooltip-arrow.north:before {
+  bottom: 100%;
+  left: 50%;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:after,
+.rich-tooltip-content .rich-tooltip-arrow.north:after {
+  border-bottom-color: #fff;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:before,
+.rich-tooltip-content .rich-tooltip-arrow.north:before {
+  border-bottom-color: #b5babf;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:after,
+.rich-tooltip-content .rich-tooltip-arrow.north:after {
+  margin-left: -15px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.north:before,
+.rich-tooltip-content .rich-tooltip-arrow.north:before {
+  margin-left: -16px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:after,
+.rich-tooltip-content .rich-tooltip-arrow.east:after,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:before,
+.rich-tooltip-content .rich-tooltip-arrow.east:before {
+  left: 100%;
+  top: 50%;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:after,
+.rich-tooltip-content .rich-tooltip-arrow.east:after {
+  border-left-color: #fff;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:before,
+.rich-tooltip-content .rich-tooltip-arrow.east:before {
+  border-left-color: #b5babf;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:after,
+.rich-tooltip-content .rich-tooltip-arrow.east:after {
+  margin-top: -15px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.east:before,
+.rich-tooltip-content .rich-tooltip-arrow.east:before {
+  margin-top: -16px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:after,
+.rich-tooltip-content .rich-tooltip-arrow.south:after,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:before,
+.rich-tooltip-content .rich-tooltip-arrow.south:before {
+  top: 100%;
+  left: 50%;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:after,
+.rich-tooltip-content .rich-tooltip-arrow.south:after {
+  border-top-color: #fff;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:before,
+.rich-tooltip-content .rich-tooltip-arrow.south:before {
+  border-top-color: #b5babf;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:after,
+.rich-tooltip-content .rich-tooltip-arrow.south:after {
+  margin-left: -15px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.south:before,
+.rich-tooltip-content .rich-tooltip-arrow.south:before {
+  margin-left: -16px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:after,
+.rich-tooltip-content .rich-tooltip-arrow.west:after,
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:before,
+.rich-tooltip-content .rich-tooltip-arrow.west:before {
+  right: 100%;
+  top: 50%;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:after,
+.rich-tooltip-content .rich-tooltip-arrow.west:after {
+  border-right-color: #fff;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:before,
+.rich-tooltip-content .rich-tooltip-arrow.west:before {
+  border-right-color: #b5babf;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:after,
+.rich-tooltip-content .rich-tooltip-arrow.west:after {
+  margin-top: -15px;
+}
+[data-rel="tooltip"] + aside .rich-tooltip-arrow.west:before,
+.rich-tooltip-content .rich-tooltip-arrow.west:before {
+  margin-top: -16px;
+}
+@media screen and (max-device-width: 480px) {
+  [data-rel="tooltip"] + aside,
+  .rich-tooltip-content {
+    max-width: 100%;
+    width: 100%;
+    left: 0;
+  }
+}
+[data-rel="tooltip"] + aside.rich-tooltip-skin-large,
+.rich-tooltip-content.rich-tooltip-skin-large,
+[data-rel="tooltip"] + aside.large,
+.rich-tooltip-content.large {
+  padding: 0;
+  -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.6);
+  -moz-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.6);
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.6);
+  -webkit-box-shadow: 5px 5px 5px 0.6 rgba(0, 0, 0, 0.4);
+  -moz-box-shadow: 5px 5px 5px 0.6 rgba(0, 0, 0, 0.4);
+  box-shadow: 5px 5px 5px 0.6 rgba(0, 0, 0, 0.4);
+}
+[data-rel="tooltip"] + aside.rich-tooltip-skin-large header,
+.rich-tooltip-content.rich-tooltip-skin-large header,
+[data-rel="tooltip"] + aside.large header,
+.rich-tooltip-content.large header {
+  padding: 20px 30px 15px 30px;
+  background: inherit;
+}
+[data-rel="tooltip"] + aside.rich-tooltip-skin-large section,
+.rich-tooltip-content.rich-tooltip-skin-large section,
+[data-rel="tooltip"] + aside.large section,
+.rich-tooltip-content.large section {
+  padding: 0 30px;
+  background: inherit;
+}
+[data-rel="tooltip"] + aside.rich-tooltip-skin-large footer,
+.rich-tooltip-content.rich-tooltip-skin-large footer,
+[data-rel="tooltip"] + aside.large footer,
+.rich-tooltip-content.large footer {
+  padding: 20px;
+}

--- a/dependencies/pointy.gestures.js
+++ b/dependencies/pointy.gestures.js
@@ -1,0 +1,247 @@
+/*!
+ * Pointy.js
+ * Pointer Events polyfill for jQuery
+ * https://github.com/vistaprint/PointyJS
+ *
+ * Depends on jQuery, see http://jquery.org
+ *
+ * Developed by Vistaprint.com
+ *
+ * pointy.gestures.js adds special events to jQuery for added fun.
+ */
+/// <reference path="pointy.js" />
+
+(function ($) {
+
+    // return a cloned copy of a given event that has been slightly modified
+    function copyEvent(originaljQEvent, type, extras) {
+        var event = originaljQEvent; // TODO: this should clone the originaljQEvent object
+
+        event.type = type;
+        event.isPropagationStopped = function () { return false; };
+        event.isDefaultPrevented = function () { return false; };
+
+        if (extras) {
+            $.extend(event, extras);
+        }
+
+        return event;
+    }
+
+    // also handles sweepleft, sweepright
+    $.event.special.sweep = {
+        // More than this horizontal displacement, and we will suppress scrolling.
+        scrollSupressionThreshold: 30,
+
+        // More time than this, and it isn't a sweep (swipe) it's a "hold" gesture.
+        durationThreshold: 750,
+
+        // Sweep horizontal displacement must be more than this.
+        horizontalDistanceThreshold: 30,
+
+        // Sweep vertical displacement must be less than this.
+        verticalDistanceThreshold: 75,
+
+        start: function (event) {
+            return {
+                time: +new Date(),
+                coords: [event.pageX, event.pageY],
+                origin: $(event.target)
+            };
+        },
+
+        stop: function (event) {
+            return {
+                time: +new Date(),
+                coords: [event.pageX, event.pageY]
+            };
+        },
+
+        isSweep: function (start, stop, checkTime) {
+            return (checkTime ? stop.time - start.time < $.event.special.sweep.durationThreshold : true) &&
+                Math.abs(start.coords[0] - stop.coords[0]) > $.event.special.sweep.horizontalDistanceThreshold &&
+                Math.abs(start.coords[1] - stop.coords[1]) < $.event.special.sweep.verticalDistanceThreshold;
+        },
+
+        add: $.event.delegateSpecial(function (handleObj) {
+            var thisObject = this,
+                $this = $(thisObject);
+
+            handleObj.pointerdown = function (event) {
+                var start = $.event.special.sweep.start(event),
+                    stop;
+
+                // we need to call prevent default because on IE browsers,
+                // dragging anything with a mouse will start dragging the
+                // element for "copy and paste" functionality
+                // on other browsers, it will start selecting text
+                // event.preventDefault();
+
+                function move(event) {
+                    if (!start) {
+                        return;
+                    }
+
+                    stop = $.event.special.sweep.stop(event);
+
+                    // prevent scrolling on touch devices
+                    if (Math.abs(start.coords[0] - stop.coords[0]) > $.event.special.sweep.scrollSupressionThreshold) {
+                        event.preventDefault();
+                    }
+                }
+
+                function up() {
+                    $this.off("pointermove", move);
+
+                    if (start && stop && $.event.special.sweep.isSweep(start, stop, true)) {
+                        var dir = start.coords[0] > stop.coords[0] ? "left" : "right";
+
+                        $.event.dispatch.call(thisObject, copyEvent(event, "sweep", { direction: dir }));
+                        $.event.dispatch.call(thisObject, copyEvent(event, "sweep" + dir, { direction: dir }));
+                    }
+
+                    start = stop = undefined;
+                }
+
+                $this
+                    .on("pointermove", move)
+                    .one("pointerup", up);
+
+                // set a timeout to ensure we cleanup, in case the "pointerup" isn't fired
+                setTimeout(function () {
+                    $this
+                        .off("pointermove", handleObj.selector, move)
+                        .off("pointerup", handleObj.selector, up);
+                }, $.event.special.sweep.durationThreshold);
+            };
+
+            $this.on("pointerdown", handleObj.selector, handleObj.pointerdown);
+        }),
+
+        remove: $.event.delegateSpecial.remove(function (handleObj) {
+            $(this).off("pointerdown", handleObj.selector, handleObj.pointerdown);
+        })
+    };
+
+    // sweepleft and sweepright are just dummies, we have to
+    // setup the handler for sweep so attach a dummy event
+    $.each(["sweepleft", "sweepright"], function (i, event) {
+        $.event.special[event] = {
+            add: $.event.delegateSpecial(function (handleObj) {
+                handleObj.noop = $.noop;
+                $(this).on("sweep", handleObj.selector, handleObj.noop);
+            }),
+
+            remove: $.event.delegateSpecial.remove(function (handleObj) {
+                $(this).off("sweep", handleObj.selector, handleObj.noop);
+            })
+        };
+    });
+
+    // utility to return the scroll-y position
+    function scrollY() {
+        return window.scrollY || $(window).scrollTop();
+    }
+
+    // also handles presshold
+    $.event.special.press = {
+        pressholdThreshold: 750,
+
+        add: $.event.delegateSpecial(function (handleObj) {
+            var thisObject = this;
+
+            handleObj.pointerdown = function (event) {
+                var start = $.event.special.sweep.start(event),
+                    startScroll = scrollY(),
+                    stop,
+                    timer,
+                    origTarget = event.target,
+                    isPresshold = false,
+                    $this = $(this);
+
+                // check that on pointermove we haven't swiped beyond the threshold for sweep
+                function move(e) {
+                    stop = $.event.special.sweep.stop(e);
+                }
+
+                // upon "pointerup", if we didn't trigger "presshold" then trigger a "press".
+                function up(event) {
+                    clearTimeout(timer);
+                    // $document.off("pointercancel", clearPressHandlers);
+
+                    // unbind the pointer move
+                    $this.off("pointermove", move);
+
+                    // check to see if they scrolled, even 5 pixels
+                    if (Math.abs(startScroll - scrollY()) > 5) {
+                        return;
+                    }
+
+                    // check to see the action should be considered a a "sweep" event
+                    if (stop && $.event.special.sweep.isSweep(start, stop)) {
+                        return;
+                    }
+
+                    // Trigger a "press" event if the start target is the same as the stop target.
+                    if (!isPresshold && origTarget === event.target) {
+                        $.event.dispatch.call(thisObject, copyEvent(event, "press"));
+                    }
+
+                    // if this was a "presshold", prevent this "pointerup" event from causing more events
+                    else if (isPresshold) {
+                        event.stopPropagation();
+                    }
+                }
+
+                $this
+                    .on("pointermove", move)
+                    .one("pointerup", up);
+
+                // TODO: if the pointer is canceled for some reason, we need to cleanup
+                // $document.on("pointercancel", clearPressHandlers);
+
+                timer = setTimeout(function () {
+                    // unbind the pointer move
+                    $this.off("pointermove", move);
+
+                    // toggle signal to ensure when the "pointerup" event we stop propagation
+                    isPresshold = true;
+
+                    // check to see if they scrolled, even 5 pixels
+                    if (Math.abs(startScroll - scrollY()) > 5) {
+                        return;
+                    }
+
+                    // check to see the action should be considered a a "sweep" event
+                    if (stop && $.event.special.sweep.isSweep(start, stop)) {
+                        return;
+                    }
+
+                    // Trigger a "presshold" event if the start target is the same as the stop target.
+                    if (origTarget === event.target) {
+                        $.event.dispatch.call(thisObject, copyEvent(event, "presshold"));
+                    }
+                }, $.event.special.press.pressholdThreshold);
+            };
+
+            $(thisObject).on("pointerdown", handleObj.selector, handleObj.pointerdown);
+        }),
+
+        remove: $.event.delegateSpecial.remove(function (handleObj) {
+            $(this).off("pointerdown", handleObj.selector, handleObj.pointerdown);
+        })
+    };
+
+    // presshold is just a dummy, it's handled by "press".
+    $.event.special.presshold = {
+        add: $.event.delegateSpecial(function (handleObj) {
+            handleObj.noop = $.noop;
+            $(this).on("press", handleObj.selector, handleObj.noop);
+        }),
+
+        remove: $.event.delegateSpecial.remove(function (handleObj) {
+            $(this).off("press", handleObj.selector, handleObj.noop);
+        })
+    };
+
+})(jQuery);

--- a/dependencies/pointy.js
+++ b/dependencies/pointy.js
@@ -1,0 +1,746 @@
+/*!
+ * Pointy.js
+ * Pointer Events polyfill for jQuery
+ * https://github.com/vistaprint/PointyJS
+ *
+ * Depends on jQuery, see http://jquery.org
+ *
+ * Developed by Vistaprint.com
+ */
+
+(function ($, window, document, undefined) {
+
+    var support = {
+        touch: "ontouchend" in document,
+        pointer: !! (navigator.pointerEnabled || navigator.msPointerEnabled)
+    };
+
+    $.extend($.support, support);
+
+    function triggerCustomEvent(elem, eventType, originalEvent) {
+        // support for IE7-IE8
+        originalEvent = originalEvent || window.event;
+
+        // Create a writable copy of the event object and normalize some properties
+        var event = new jQuery.Event(originalEvent);
+        event.type = eventType;
+
+        // Copy over properties for ease of access
+        var i, copy = $.event.props.concat($.event.pointerHooks.props);
+        i = copy.length;
+        while (i--) {
+            var prop = copy[i];
+            event[prop] = originalEvent[prop];
+        }
+
+        // Support: IE<9
+        // Fix target property (#1925)
+        if (!event.target) {
+            event.target = originalEvent.srcElement || document;
+        }
+
+        // Support: Chrome 23+, Safari?
+        // Target should not be a text node (#504, #13143)
+        if (event.target.nodeType === 3) {
+            event.target = event.target.parentNode;
+        }
+
+        // Support: IE<9
+        // For mouse/key events, metaKey==false if it's undefined (#3368, #11328)
+        event.metaKey = !! event.metaKey;
+
+        // run the filter now
+        event = $.event.pointerHooks.filter(event, originalEvent);
+
+        // trigger the emulated pointer event
+        // the filter can return an array (only if the original was a touchmove),
+        // which means we need to trigger independent events
+        if ($.isArray(event)) {
+            $.each(event, function (i, ev) {
+                $.event.dispatch.call(elem, ev);
+            });
+        } else {
+            $.event.dispatch.call(elem, event);
+        }
+
+        // return the manipulated jQuery event
+        return event;
+    }
+
+    function addEvent(elem, type, selector, func) {
+        // when we have a selector, let jQuery do the delegation
+        if (selector) {
+            func._pointerEventWrapper = function (event) {
+                return func.call(elem, event.originalEvent);
+            };
+
+            $(elem).on(type, selector, func._pointerEventWrapper);
+        }
+
+        // if we do not have a selector, we optimize by cutting jQuery out
+        else {
+            if (elem.addEventListener) {
+                elem.addEventListener(type, func, false);
+            } else if (elem.attachEvent) {
+
+                // bind the function to correct "this" for IE8-
+                func._pointerEventWrapper = function (e) {
+                    return func.call(elem, e);
+                };
+
+                elem.attachEvent("on" + type, func._pointerEventWrapper);
+            }
+        }
+    }
+
+    function removeEvent(elem, type, selector, func) {
+        // Make sure for IE8- we unbind the wrapper
+        if (func._pointerEventWrapper) {
+            func = func._pointerEventWrapper;
+        }
+
+        if (selector) {
+            $(elem).off(type, selector, func);
+        } else {
+            $.removeEvent(elem, type, func);
+        }
+    }
+
+    // get the standardized "buttons" property as per the Pointer Events spec from a mouse event
+    function getStandardizedButtonsProperty(event) {
+        // in the DOM LEVEL 3 spec there is a new standard for the "buttons" property
+        // sadly, no browser currently supports this and only sends us the single "button" property
+        if (event.buttons) {
+            return event.buttons;
+        }
+
+        // standardize "which" property for use
+        var which = event.which;
+        if (!which && event.button !== undefined) {
+            which = (event.button & 1 ? 1 : (event.button & 2 ? 3 : (event.button & 4 ? 2 : 0)));
+        }
+
+        // no button down (can happen on mousemove)
+        if (which === 0) {
+            return 0;
+        }
+        // left button
+        else if (which === 1) {
+            return 1;
+        }
+        // middle mouse
+        else if (which === 2) {
+            return 4;
+        }
+        // right mouse
+        else if (which === 3) {
+            return 2;
+        }
+
+        // unknown?
+        return 0;
+    }
+
+    function returnFalse() { return false; }
+    function returnTrue() { return true; }
+
+    var POINTER_TYPE_UNAVAILABLE = "unavailable";
+    var POINTER_TYPE_TOUCH = "touch";
+    var POINTER_TYPE_PEN = "pen";
+    var POINTER_TYPE_MOUSE = "mouse";
+
+    // indicator to mark whether touch events are in progress
+    // when null, it means we have never received a touch event
+    // when number, user is currently touching something
+    // when false, user just released their finger (reset on mousedown if needed)
+    var _touching = null;
+
+    // bitmask to identify which buttons are currently down
+    var _buttons = 0;
+
+    // storage of the last seen touches provided by the native touch events spec
+    var _lastTouches = [];
+
+    // ------ NOTE: THIS IS UNUSED, WE DO NOT ASSIGN BUTTON ------
+    // pointer events defines the "button" property as:
+    // mouse move (no buttons down)                         -1
+    // left mouse, touch contact and normal pen contact     0
+    // middle mouse                                         1
+    // right mouse, pen with barrel button pressed          2
+    // x1 (back button on mouse)                            3
+    // x2 (forward button on mouse)                         4
+    // pen contact with eraser button pressed               5
+    // ------ NOTE: THIS IS UNUSED, WE DO NOT ASSIGN BUTTON ------
+
+    // pointer events defines the "buttons" property as:
+    // mouse move (no buttons down)                         0
+    // left mouse, touch contact, and normal pen contact    1
+    // middle mouse                                         4
+    // right mouse, pen contact with barrel button pressed  2
+    // x1 (back) mouse                                      8
+    // x2 (forward) mouse                                   16
+    // pen contact with eraser button pressed               32
+
+    // add our own pointer event hook/filter
+    $.event.pointerHooks = {
+        props: "pointerType pointerId pressure buttons clientX clientY relatedTarget fromElement offsetX offsetY pageX pageY screenX screenY width height toElement".split(" "),
+        filter: function (event, original) {
+            // Calculate pageX/Y if missing and clientX/Y available
+            // this is just copied from jQuery's standard pageX/pageY fix
+            if (!original.touches && event.pageX == null && original.clientX != null) {
+                var eventDoc = event.target.ownerDocument || document;
+                var doc = eventDoc.documentElement;
+                var body = eventDoc.body;
+
+                event.pageX = original.clientX + (doc && doc.scrollLeft || body && body.scrollLeft || 0) - (doc && doc.clientLeft || body && body.clientLeft || 0);
+                event.pageY = original.clientY + (doc && doc.scrollTop || body && body.scrollTop || 0) - (doc && doc.clientTop || body && body.clientTop || 0);
+            }
+
+            // Add relatedTarget, if necessary
+            // also copied from jQuery's standard event fix
+            if (!event.relatedTarget && original.fromElement) {
+                event.relatedTarget = original.fromElement === event.target ? original.toElement : original.fromElement;
+            }
+
+            // Add pointerType
+            if (!event.pointerType || typeof event.pointerType === "number") {
+                if (event.pointerType == 2) {
+                    event.pointerType = POINTER_TYPE_TOUCH;
+                } else if (event.pointerType == 3) {
+                    event.pointerType = POINTER_TYPE_PEN;
+                } else if (event.pointerType == 4) {
+                    event.pointerType = POINTER_TYPE_MOUSE;
+                } else if (/^touch/i.test(original.type)) {
+                    event.pointerType = POINTER_TYPE_TOUCH;
+                    event.buttons = original.type === "touchend" || original.type === "touchcancel" ? 0 : 1;
+                } else if (/^mouse/i.test(original.type) || original.type === "click") {
+                    event.pointerId = 1; // as per the pointer events spec, the mouse is always pointer id 1
+                    event.pointerType = POINTER_TYPE_MOUSE;
+                    event.buttons = original.type === "mouseup" ? 0 : getStandardizedButtonsProperty(original);
+                } else {
+                    event.pointerType = POINTER_TYPE_UNAVAILABLE;
+                    event.buttons = 0;
+                }
+            }
+
+            // if we have the bitmask for the depressed buttons from the mouse events polyfill, use it to mimic buttons for
+            // browsers that do not support the HTML DOM LEVEL 3 events spec
+            if (event.type !== "pointerdown" && event.pointerType === "mouse" && _touching === null && _buttons !== event.buttons) {
+                event.buttons = _buttons;
+            }
+
+            // standardize the pressure attribute
+            if (!event.pressure) {
+                event.pressure = event.buttons > 0 ? 0.5 : 0;
+            }
+
+            // standardize the width and height, these represent the contact geometry
+            if (event.width === undefined || event.height === undefined) {
+                event.width = event.height = 0;
+            }
+
+            // prevent the following native "click" event from occurring, can be used to prevent
+            // clicks on "pointerdown" or "pointerup" or from gestures like "press" and "presshold"
+            event.preventClick = function () {
+                event.isClickPrevented = returnTrue;
+                $(event.target).one("click", returnFalse);
+            };
+
+            event.isClickPrevented = returnFalse;
+
+            // touch events send an array of touches we need to convert to the pointer events format
+            // which means we need to fire multiple events per touch
+            if (original.touches && event.type !== "pointercancel") {
+                var touches = original.touches;
+                var events = [];
+                var ev, i, j;
+
+                // the problem with this is that on "touchend" it will remove the
+                // touch which has ended from the touches list, this means we do
+                // not want to fire "pointerup" for touches that are still there,
+                // we instead want to send a "pointerup" with the removed touch's identifier
+                if (event.type === "pointerup") {
+                    // convert TouchList to a standard array
+                    _lastTouches = Array.prototype.slice.call(_lastTouches);
+
+                    // find the touch that was removed
+                    for (i = 0; i < original.touches.length; i++) {
+                        for (j = 0; j < _lastTouches.length; j++) {
+                            if (_lastTouches[j].identifier === original.touches[i].identifier) {
+                                _lastTouches.splice(j, 1);
+                            }
+                        }
+                    }
+
+                    // if we narrowed down the ended touch to one, then we found it
+                    if (_lastTouches.length === 1) {
+                        event.pointerId = _lastTouches[0].identifier;
+                        _lastTouches = original.touches;
+                        return event;
+                    }
+                }
+                // on "pointerdown" we need to only trigger a new "pointerdown" for the new touches (fingers),
+                // and not the touches that were already active. Therefore we filter out all of the touches
+                // based on their identifier that we already knew were active before
+                else if (event.type === "pointerdown") {
+                    // convert TouchList to a standard array
+                    touches = Array.prototype.slice.call(original.touches);
+
+                    // find the new touch that was just added
+                    for (i = 0; i < touches.length; i++) {
+                        // last touches will be a list with one less touch
+                        for (j = 0; j < _lastTouches.length; j++) {
+                            if (touches[i].identifier === _lastTouches[j].identifier) {
+                                touches.splice(i, 1);
+                            }
+                        }
+                    }
+                }
+
+                // this will be used on pointermove and pointerdown
+                for (i = 0; i < original.touches.length; i++) {
+                    var touch = original.touches[i];
+                    ev = $.extend({}, event);
+                    // copy over information from the touch to the event
+                    ev.clientX = touch.clientX;
+                    ev.clientY = touch.clientY;
+                    ev.pageX = touch.pageX;
+                    ev.pageY = touch.pageY;
+                    ev.screenX = touch.screenX;
+                    ev.screenY = touch.screenY;
+                    // the touch id on emulated touch events from chrome is always 0 (zero)
+                    ev.pointerId = touch.identifier;
+                    events.push(ev);
+                }
+
+                // do as little processing as you can here, this is done on touchmove and
+                // there can be a lot of those events firing quickly, we do not want the
+                // polyfill slowing down the application
+                _lastTouches = original.touches;
+                return events;
+            }
+
+            return event;
+        }
+    };
+
+    $.event.delegateSpecial = function (setup) {
+        return function (handleObj) {
+            var thisObject = this,
+                data = jQuery._data(thisObject);
+
+            if (!data.pointerEvents) {
+                data.pointerEvents = {};
+            }
+
+            if (!data.pointerEvents[handleObj.type]) {
+                data.pointerEvents[handleObj.type] = [];
+            }
+
+            if (!data.pointerEvents[handleObj.type].length) {
+                setup.call(thisObject, handleObj);
+            }
+
+            data.pointerEvents[handleObj.type].push(handleObj);
+        };
+    };
+
+    var indexOfArray = function (arr, obj) {
+        if (arr.indexOf) {
+            return arr.indexOf(obj);
+        }
+
+        for (var i=0; i<arr.length; i++) {
+            if (arr[i] === obj) {
+                return i;
+            }
+        }
+
+        return -1;
+    };
+
+    $.event.delegateSpecial.remove = function (teardown) {
+        return function (handleObj) {
+            var handlers,
+                thisObject = this,
+                data = jQuery._data(thisObject);
+
+            if (!data.pointerEvents) {
+                data.pointerEvents = {};
+            }
+
+            handlers = data.pointerEvents[handleObj.type];
+
+            handlers.splice(indexOfArray(handlers, handleObj), 1);
+
+            if (!handlers.length) {
+                teardown.call(thisObject, handleObj);
+            }
+        };
+    };
+
+    // allow jQuery's native $.event.fix to find our pointer hooks
+    $.extend($.event.fixHooks, {
+        pointerdown: $.event.pointerHooks,
+        pointerup: $.event.pointerHooks,
+        pointermove: $.event.pointerHooks,
+        pointerover: $.event.pointerHooks,
+        pointerout: $.event.pointerHooks,
+        pointercancel: $.event.pointerHooks
+    });
+
+    // if browser does not natively handle pointer events,
+    // create special custom events to mimic them
+    if (!support.pointer) {
+        // stores the scroll-y offest on "touchstart" and is compared
+        // on touchend to see if we should trigger a click event
+        var _startScrollOffset;
+
+        // utility to return the scroll-y position
+        var scrollY = function () {
+            return Math.floor(window.scrollY || $(window).scrollTop());
+        };
+
+        $.event.special.pointerdown = {
+            touch: function (event) {
+                // set the pointer as currently down to prevent chorded "pointerdown" events
+                _touching = event.timeStamp;
+
+                // trigger a new "pointerdown" event
+                triggerCustomEvent(this, "pointerdown", event);
+
+                // set the scroll offset which is compared on TouchEnd
+                _startScrollOffset = scrollY();
+
+                // no matter what, you cannot simply always call preventDefault() on "touchstart"
+                // this disables scrolling when touching the binded element, which is not appropriate.
+            },
+            mouse: function (event) {
+                // if we just had a "touchstart", ignore this "mousedown" event, to prevent double firing of "pointerdown"
+                if (typeof _touching === "number") {
+                    return;
+                }
+
+                // we reset the touch to null, to indicate that we're listening to mouse events currently
+                _touching = null;
+
+                // update the _buttons bitmask
+                var button = getStandardizedButtonsProperty(event);
+                var wasAButtonDownAlready = _buttons !== 0;
+                _buttons |= button;
+
+                // do not trigger another "pointerdown" event if a button is currently down,
+                // this prevents chorded "pointerdown" events which is defined in the Pointer Events spec
+                if (wasAButtonDownAlready && _buttons !== button) {
+                    // per the Pointer Events spec, when the active buttons change it fires only a "pointermove" event
+                    triggerCustomEvent(this, "pointermove", event);
+                    return;
+                }
+
+                triggerCustomEvent(this, "pointerdown", event);
+            },
+            add: $.event.delegateSpecial(function (handleObj) {
+                // bind to touch events, some devices (chromebook) can send both touch and mouse events
+                if (support.touch) {
+                    addEvent(this, "touchstart", handleObj.selector, $.event.special.pointerdown.touch);
+                }
+
+                // bind to mouse events
+                addEvent(this, "mousedown", handleObj.selector, $.event.special.pointerdown.mouse);
+
+                // ensure we also bind to "pointerup" to properly clear signals and fire click event on "touchend"
+                handleObj.pointerup = $.noop;
+                $(this).on("pointerup", handleObj.selector, handleObj.pointerup);
+            }),
+            remove: $.event.delegateSpecial.remove(function (handleObj) {
+                // unbind touch events
+                if (support.touch) {
+                    removeEvent(this, "touchstart", handleObj.selector, $.event.special.pointerdown.touch);
+                }
+
+                // unbind mouse events
+                removeEvent(this, "mousedown", handleObj.selector, $.event.special.pointerdown.mouse);
+
+                // unbind the special "pointerup" we added for cleanup
+                if (handleObj.pointerup) {
+                    $(this).off("pointerup", handleObj.selector, handleObj.pointerup);
+                }
+            })
+        };
+
+        $.event.special.pointerup = {
+            touch: function (event) {
+                // prevent default to prevent the emulated "mouseup" event from being triggered
+                event.preventDefault();
+
+                // safety check, if _touching is null then we just had a mouse event and shouldn't
+                // listen to touch events right now
+                if (_touching === null) {
+                    return;
+                }
+
+                // timeStamp of when the last "touchstart" event was triggered,
+                // used to prevent double fire issues on iOS 7+ devices when needed
+                var lastTouchStarted = _touching;
+
+                // trigger the emulated "pointerup" event, getting back the event
+                var jEvent = triggerCustomEvent(this, "pointerup", event);
+
+                // ensure we have a target before we attempt to deal with a "click" event
+                if (!event.target) {
+                    _touching = false; // release the "pointerdown" lock
+                    return;
+                }
+
+                // while you may think if we are preventing the next "click" event (see jEvent.isClickPrevented)
+                // we could simply not trigger one below, that turns out to be a bad assumption. Due to the
+                // complex issue of dealing with various devices, often a click event is triggered regardless of
+                // calling preventDefault on "touchend" so we have to still go on and determine if a "click"
+                // event was triggered, if so, render it noop, if not, we don't have to trigger one then.
+
+                // we confirm that the user did not scroll, as touch events are very related to scrolling on
+                // touch devices, it's possible we may mis-fire a click event on an <a> anchor tag causing
+                // navigation even though this was a scroll attempt. We let the browser's built in scrolling
+                // threshold prevent accidental scrolling so we only need to check if they scrolled at all.
+                if (_startScrollOffset !== scrollY()) {
+                    _touching = false; // release the "pointerdown" lock
+                    return;
+                }
+
+                // on "touchend", calling prevent default prevents the "mouseup" and "click" event
+                // however on native "mouseup" events preventing default does not cancel the "click" event
+                // as per the pointer event spec on "pointerup" preventing default should not cancel the "click" event
+                //
+                // so we really want to have a "click" event all the time. If a function binded to this emulated
+                // "poiunterup" calls prevent default it would result in preventing the "click" event, which would
+                // cause inconsistent behavior. To prevent the possibility of two click events though, we call
+                // prevent default all the time (see above) and then trigger a "click" event here.
+                //
+                // Additionally, we are currently looking at the "touchend" event, mobile devices usually add a 300ms
+                // delay before triggering click to check for double tap events (zooming action on most devices).
+                // In certain situations the mobile device will still fire a "click" event even if preventDefault is
+                // called on "touchend", so we wait the 300ms and look for a click, then only fire a click if none
+                // was fired by the browser
+                var clickTimer = setTimeout(function () {
+                    if (_touching === lastTouchStarted) {
+                        _touching = false; // release the "pointerdown" lock
+                    }
+
+                    // at this point, if no click event was triggered, and we don't want to to trigger a "click"
+                    // event, we can simply not trigger one to begin with.
+                    if (jEvent.isClickPrevented()) {
+                        $(event.target).off("click", returnFalse);
+                        return;
+                    }
+
+                    if (event.target.click) {
+                        event.target.click();
+                    } else {
+                        // iOS 5 and older Android browsers do not define native .click events on all elements
+                        $(event.target).click();
+                    }
+                }, 300);
+
+                $(event.target).one("click", function () {
+                    if (_touching === lastTouchStarted) {
+                        _touching = false;
+                    }
+
+                    if (clickTimer) {
+                        clearTimeout(clickTimer);
+                    }
+                });
+            },
+            mouse: function (event) {
+                // if originally we had a "touchstart" or we ended with a "touchend" event, ignore this "mouseup"
+                if (_touching !== null) {
+                    return;
+                }
+
+                // on mouseup, the event.button will be the button that was just released
+                _buttons ^= getStandardizedButtonsProperty(event);
+
+                // we only trigger a "pointerup" event if no buttons are down, prevent chorded PointerDown events
+                if (_buttons === 0) {
+                    triggerCustomEvent(this, "pointerup", event);
+                } else {
+                    // per the Pointer Events spec, when the active buttons change it fires only a PointerMove event
+                    triggerCustomEvent(this, "pointermove", event);
+                }
+
+                // Mouse Events spec shows that after a "mouseup" it fires a "mousemove", which will trigger
+                // the "pointermove" needed to follow the Pointer Events spec which describes the same thing
+            },
+            add: $.event.delegateSpecial(function (handleObj) {
+                // bind to touch events, some devices (chromebook) can send both touch and mouse events
+                if (support.touch) {
+                    addEvent(this, "touchend", handleObj.selector, $.event.special.pointerup.touch);
+                }
+
+                // bind mouse events
+                addEvent(this, "mouseup", handleObj.selector, $.event.special.pointerup.mouse);
+            }),
+            remove: $.event.delegateSpecial.remove(function (handleObj) {
+                // unbind touch events
+                if (support.touch) {
+                    removeEvent(this, "touchend", handleObj.selector, $.event.special.pointerup.touch);
+                }
+
+                // unbind mouse events
+                removeEvent(this, "mouseup", handleObj.selector, $.event.special.pointerup.mouse);
+            })
+        };
+
+        $.event.special.pointermove = {
+            touch: function (event) {
+                triggerCustomEvent(this, "pointermove", event);
+            },
+            mouse: function (event) {
+                // _touching will be a number if they currently have their finger (touch only) down
+                // because we cannot call preventDefault on the "touchmove" without preventing
+                // scrolling on most things, we do this check to ensure we don't double fire
+                // move events.
+                if (typeof _touching === "number") {
+                    return;
+                }
+
+                triggerCustomEvent(this, "pointermove", event);
+            },
+            add: $.event.delegateSpecial(function (handleObj) {
+                // bind to touch events, some devices (chromebook) can send both touch and mouse events
+                if (support.touch) {
+                    addEvent(this, "touchmove", handleObj.selector, $.event.special.pointermove.touch);
+                }
+
+                // bind mouse events
+                addEvent(this, "mousemove", handleObj.selector, $.event.special.pointermove.mouse);
+            }),
+            remove: $.event.delegateSpecial.remove(function (handleObj) {
+                // unbind touch events
+                if (support.touch) {
+                    removeEvent(this, "touchmove", handleObj.selector, $.event.special.pointermove.touch);
+                }
+
+                // unbind mouse events
+                removeEvent(this, "mousemove", handleObj.selector, $.event.special.pointermove.mouse);
+            })
+        };
+
+        jQuery.each({
+            pointerover: {
+                mouse: "mouseover"
+            },
+            pointerout: {
+                mouse: "mouseout"
+            },
+            pointercancel: {
+                touch: "touchcancel"
+            }
+        }, function (pointerEventType, natives) {
+            function onTouch(event) {
+                // pointercancel, reset everything
+                if (event.type === "touchcancel") {
+                    _touching = null;
+                    _buttons = 0;
+                }
+
+                triggerCustomEvent(this, pointerEventType, event);
+            }
+
+            function onMouse(event) {
+                triggerCustomEvent(this, pointerEventType, event);
+            }
+
+            $.event.special[pointerEventType] = {
+                setup: function () {
+                    if (support.touch && natives.touch) {
+                        addEvent(this, natives.touch, null, onTouch);
+                    }
+                    if (natives.mouse) {
+                        addEvent(this, natives.mouse, null, onMouse);
+                    }
+                },
+                teardown: function () {
+                    if (support.touch && natives.touch) {
+                        removeEvent(this, natives.touch, null, onTouch);
+                    }
+                    if (natives.mouse) {
+                        removeEvent(this, natives.mouse, null, onMouse);
+                    }
+                }
+            };
+        });
+    }
+
+    // for IE10 specific, we proxy though events so we do not need to deal
+    // with the various names or renaming of events.
+    else if (navigator.msPointerEnabled && !navigator.pointerEnabled) {
+        $.extend($.event.special, {
+            pointerdown: {
+                delegateType: "MSPointerDown",
+                bindType: "MSPointerDown"
+            },
+            pointerup: {
+                delegateType: "MSPointerUp",
+                bindType: "MSPointerUp"
+            },
+            pointermove: {
+                delegateType: "MSPointerMove",
+                bindType: "MSPointerMove"
+            },
+            pointerover: {
+                delegateType: "MSPointerOver",
+                bindType: "MSPointerOver"
+            },
+            pointerout: {
+                delegateType: "MSPointerOut",
+                bindType: "MSPointerOut"
+            },
+            pointercancel: {
+                delegateType: "MSPointerCancel",
+                bindType: "MSPointerCancel"
+            }
+        });
+
+        $.extend($.event.fixHooks, {
+            MSPointerDown: $.event.pointerHooks,
+            MSPointerUp: $.event.pointerHooks,
+            MSPointerMove: $.event.pointerHooks,
+            MSPointerOver: $.event.pointerHooks,
+            MSPointerOut: $.event.pointerHooks,
+            MSPointerCancel: $.event.pointerHooks
+        });
+    }
+
+    // add support for pointerenter and pointerlave
+    // pointerenter and pointerleave were added in IE11, they do not exist in IE10
+    if (!support.pointer || (navigator.msPointerEnabled && !navigator.pointerEnabled)) {
+        // Create a wrapper similar to jQuery's mouseenter/leave events
+        // using pointer events (pointerover/out) and event-time checks
+        jQuery.each({
+            pointerenter: navigator.msPointerEnabled ? "MSPointerOver" : "mouseover",
+            pointerleave: navigator.msPointerEnabled ? "MSPointerOut" : "mouseout"
+        }, function (orig, fix) {
+            jQuery.event.special[orig] = {
+                delegateType: fix,
+                bindType: fix,
+                handle: function (event) {
+                    var ret,
+                        target = this,
+                        related = event.relatedTarget,
+                        handleObj = event.handleObj;
+
+                    // For mousenter/leave call the handler if related is outside the target.
+                    // NB: No relatedTarget if the mouse left/entered the browser window
+                    if (!related || (related !== target && !jQuery.contains(target, related))) {
+                        event.type = handleObj.origType;
+                        ret = handleObj.handler.apply(this, arguments);
+                        event.type = fix;
+                    }
+                    return ret;
+                }
+            };
+        });
+    }
+
+})(jQuery, window, document);

--- a/installation.md
+++ b/installation.md
@@ -6,10 +6,10 @@
  * http://nodejs.org/download/
 
 * Install grunt
- * You can install grunt by using npm, run the following command: 
+ * You can install grunt by using npm. Run the following command: 
  * ```npm install -g grunt-cli```
 
-* From the repo's working directory, install NPM packages
+* From the repo's working directory, install NPM packages:
  * ```npm install```
 
 * Before committing, run grunt (default task)
@@ -21,7 +21,6 @@
 skinny.js has a hard dependency on pointy.js, and keeps a local copy of pointy.js just as if it was a regular skinny.js module. 
 
 To update pointy.js:
-
 * Run ```grunt update
 * Then commit any changes to pointy.js or pointy.gestures.js
 

--- a/js/jquery.modalDialog.js
+++ b/js/jquery.modalDialog.js
@@ -439,7 +439,7 @@
                 '<div class="dialog-container" id="' + this.settings._fullId + 'Container">' +
                 '  <div class="dialog-header">' +
                 '    <a href="#" class="dialog-close-button"><span class="dialog-close-button-icon"></span></a>' +
-                '    <h1>' + (this.settings.title || "") + '</h1>' +
+                '    <h2 class="dialog-header-text">' + (this.settings.title || "") + '</h2>' +
                 '  </div>' +
                 '  <div class="dialog-content-container">' +
                 '  </div>' +
@@ -701,12 +701,12 @@
 
     // Sets the title of the dialog in the header.
     ModalDialog.prototype.setTitle = function (title) {
-        this.$container.find(".dialog-header h1").text(title || "");
+        this.$container.find(".dialog-header .dialog-header-text").text(title || "");
     };
 
     // Gets the title of the dialog in the header.
     ModalDialog.prototype.getTitle = function () {
-        return this.$container.find(".dialog-header h1").text();
+        return this.$container.find(".dialog-header .dialog-header-text").text();
     };
 
     // Extends ModalDialog such that the content is an iframe.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-jsbeautifier": "~0.2.7",
     "grunt-lineending": "~0.2.2",
     "grunt-mkdir": "~0.1.2",
-    "grunt-js-test": "~1.4.8",
+    "grunt-js-test": "~1.5.12",
     "grunt-string-replace": "~0.2.7",
     "grunt-strip-code": "~0.1.2",
     "grunt-wget": "~0.1.2",
@@ -58,6 +58,9 @@
     },
     {
       "name": "Ilya Volodin"
+    },
+    {
+      "name": "Jeff Yaus"
     }
   ],
   "license": "Apache 2"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "file": "0.2.2",
     "grunt": "^0.4.5",
@@ -14,7 +13,7 @@
     "grunt-contrib-compress": "~0.10.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jshint": "~0.11.1",
     "grunt-contrib-less": "~0.11.4",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",

--- a/test/content/ui-components.html
+++ b/test/content/ui-components.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<title>SkinnyJS UI Components test page</title>
+
+<link rel="stylesheet" href="../../css/jquery.modalDialog.css" />
+<link rel="stylesheet" href="../../css/jquery.modalDialog.skins.css" />
+<link rel="stylesheet" href="../../css/jquery.richTooltip.css" />
+
+<script type="text/javascript" src="../../dependencies/jquery.js"></script>
+<script type="text/javascript" src="../../dependencies/pointy.js"></script>
+
+<script type="text/javascript" src="../../js/jquery.clientRect.js" /></script>
+<script type="text/javascript" src="../../js/jquery.customEvent.js" /></script>
+<script type="text/javascript" src="../../js/jquery.delimitedString.js" /></script>
+<script type="text/javascript" src="../../js/jquery.hostIframe.js" /></script>
+<script type="text/javascript" src="../../js/jquery.partialLoad.js" /></script>
+<script type="text/javascript" src="../../js/jquery.postMessage.js" /></script>
+<script type="text/javascript" src="../../js/jquery.proxyAll.js" /></script>
+<script type="text/javascript" src="../../js/jquery.queryString.js" /></script>
+<script type="text/javascript" src="../../js/jquery.postMessage.js" /></script>
+<script type="text/javascript" src="../../js/jquery.customEvent.js" /></script>
+<script type="text/javascript" src="../../js/jquery.contentSize.js" /></script>
+<script type="text/javascript" src="../../js/jquery.disableEvent.js" /></script>
+<script type="text/javascript" src="../../js/jquery.calcRestrainedPos.js" /></script>
+
+<script type="text/javascript" src="../../js/jquery.modalDialogContent.header.js"></script>
+<script type="text/javascript" src="../../js/jquery.modalDialog.userAgent.js"></script>
+<script type="text/javascript" src="../../js/jquery.modalDialog.getSettings.js"></script>
+<script type="text/javascript" src="../../js/jquery.modalDialog.deviceFixes.js"></script> 
+<script type="text/javascript" src="../../js/jquery.modalDialog.unobtrusive.js"></script>
+<script type="text/javascript" src="../../js/jquery.modalDialog.js"></script>
+<script type="text/javascript" src="../../js/jquery.richTooltip.js"></script>
+
+<style>
+body
+{
+    font-family: sans-serif;
+    padding: 0 2em;
+}
+.skinny-heading
+{
+    margin-top: 2em;
+    font-family: Georgia, serif;
+    font-style: italic;
+    font-weight: bold;
+    color: #63A52A;
+    text-decoration: none;
+}
+</style>
+
+</head>
+<body>
+<h1 class="skinny-heading">skinny.js UI Components test page</h1>
+<p>
+    (For local development/testing of skinny.js components)
+</p>
+
+<h2 class="skinny-heading">Modal dialogs</h2>
+<p>
+    To launch a modal dialog that uses the unobtrusive syntax, <a href="#modalUnobtrusive" data-rel="modalDialog">click here</a>.
+</p>
+
+<p>
+    To launch a modal dialog that uses the programmatic syntax, <a href="#modalUnobtrusive" id="modalProgrammaticLauncher">click here</a>.
+</p>
+
+<div class="dialog-content" id="modalUnobtrusive" data-dialog-title="Unobtrusive Syntax">
+    <div>Modal dialogs are delicious, and good for you too.</div>
+</div>
+
+<script>
+$("#modalProgrammaticLauncher").click(function() {
+    $("#modalProgrammatic").modalDialog();
+});
+</script>
+
+<div class="dialog-content" id="modalProgrammatic" data-dialog-title="Programmatic Syntax">
+    Modal dialogs are delicious, and good for you too.
+</div>
+
+<h2 class="skinny-heading">Rich Tooltips</h2>
+<p>
+    To see a tooltip that uses a selector, <a href="#" data-tooltip="#myTooltip">click here</a>.
+</p>
+<aside id="myTooltip" class="rich-tooltip">
+    Tooltip content for "selector" usage.
+</aside>
+
+<a href="#" data-rel="tooltip">Click here</a> to see a tooltip that uses the "adjacent elements" convention.
+<aside>
+    Tooltip content for "adjacent elements" usage.
+</aside>
+
+</body>
+</html>

--- a/test/jquery.modalDialog.iframe.unittests.js
+++ b/test/jquery.modalDialog.iframe.unittests.js
@@ -26,7 +26,7 @@ describe("jquery.modalDialog.create", function () {
             .open()
             .then(wait)
             .then(function () {
-                var title = $.trim($(".dialog-header h1").text());
+                var title = $.trim($(".dialog-header .dialog-header-text").text());
 
                 assert.equal(title, "explicit title");
 
@@ -49,7 +49,7 @@ describe("jquery.modalDialog.create", function () {
             .open()
             .then(wait)
             .then(function () {
-                var title = $.trim($(".dialog-header h1").text());
+                var title = $.trim($(".dialog-header .dialog-header-text").text());
 
                 assert.equal(title, "ModalDialog iframe content");
 


### PR DESCRIPTION
(for Vistaprint ticket SF-9583)
* Change the modal dialog title from an h1 to an h2, and style it via a CSS class

Also:
* Provide .css versions of stylesheets, which our documentation says we do, but we weren't actually doing so
* Create a test page so that you can debug skinny UI components within the package
* Add pointy.js to the /dependencies folder, for use in test pages
* Update version of grunt-contrib-jshint to eliminate error during grunt
* Remove IE7-8 support