### PR TITLE
Stopping multiple dialog bg clicks from throwing errors

### DIFF
--- a/js/jquery.modalDialog.js
+++ b/js/jquery.modalDialog.js
@@ -476,7 +476,13 @@
             this.$closeButton = this.$el.find(".dialog-close-button").on("click", this._close);
             if (this.settings.closeOnBackgroundClick)
             {
-                this.$bg.on("click", this._close); // clicks on the background veil also close the dialog
+                // clicks on the background veil also close the dialog
+                var curDialog = this;
+                this.$bg.on("click", function(e) {
+                    if (curDialog === $.modalDialog.getCurrent()) {
+                        curDialog._close(e);
+                    }
+                });
             }
 
             this._buildContent();


### PR DESCRIPTION
If the user clicks multiple times quickly on a modal dialog background, the triggered _close() calls will throw the error "Can't close a dialog that isn't currently displayed on top."  This is because the event doesn't check if the dialog is still open, and then user can click multiple times on the background before closing.  This adds an additional check in the event handler.

Another, simpler option, would be to just not throw an error in the close() function, and simply return if the dialog is not current.  This means that no methods of trying to close an already closed dialog would error.  The only potential down-side might be that user code that tried to close dialogs when it shouldn't would see the error it currently sees.